### PR TITLE
chore: scripts should deploy latest default dhis2

### DIFF
--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -20,8 +20,8 @@ function createDatabase() {
 }
 
 ## https://databases.dhis2.org/
-createDatabase "Sierra Leone - 2.36.11" https://databases.dhis2.org/sierra-leone/2.36.0/dhis2-db-sierra-leone.sql.gz
-createDatabase "Sierra Leone - 2.37.7" https://databases.dhis2.org/sierra-leone/2.37.6/dhis2-db-sierra-leone.sql.gz
 createDatabase "Sierra Leone - 2.38.1" https://databases.dhis2.org/sierra-leone/2.38.1/dhis2-db-sierra-leone.sql.gz
+createDatabase "Sierra Leone - 2.37.7" https://databases.dhis2.org/sierra-leone/2.37.6/dhis2-db-sierra-leone.sql.gz
+createDatabase "Sierra Leone - 2.36.11" https://databases.dhis2.org/sierra-leone/2.36.0/dhis2-db-sierra-leone.sql.gz
 
 ./list.sh | jq '.[].Databases[] | .ID, .Name, .Url'


### PR DESCRIPTION
relates to https://github.com/dhis2-sre/im-manager/pull/86 deploying 2.38 by default. The
database ID of 1 needs to match the DHIS2 version.