### PR TITLE
chore: add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.env
+.env.example
+.envrc
+.git
+.github
+.gitignore
+helm
+Makefile
+*.md
+.pre-commit-config.yaml
+scripts
+.idea
+docker-compose.yml
+skaffold.yaml


### PR DESCRIPTION
So we do not rebuild unnecessarily during `skaffold dev` Copied from im-manager.

